### PR TITLE
feat: 환율 계산기 구현 완료(FE, BE)

### DIFF
--- a/back/zzocco_money/currency/urls.py
+++ b/back/zzocco_money/currency/urls.py
@@ -4,5 +4,4 @@ from . import views
 app_name = 'currency'
 urlpatterns = [
     path('get_exchange_rates/', views.get_exchange_rates),
-    path('convert', views.currency_converter), 
 ]

--- a/back/zzocco_money/currency/views.py
+++ b/back/zzocco_money/currency/views.py
@@ -17,31 +17,13 @@ def get_exchange_rates(request):
     response = requests.get(url, params=params)
     exchange_rates = response.json()
 
-    data = {}
+    data = []
     for rate in exchange_rates:
-        cur_unit = rate['cur_unit']
-        deal_bas_r = float(rate['deal_bas_r'].replace(',', '')) #숫자로 저장하기
-        data[cur_unit] = deal_bas_r
+        currency_info = {
+            'cur_unit': rate['cur_unit'],
+            'cur_nm': rate['cur_nm'],
+            'deal_bas_r': float(rate['deal_bas_r'].replace(',', ''))
+        }
+        data.append(currency_info)
 
     return Response(data)
-
-@api_view(['POST'])
-def currency_converter(request):
-
-    amount = float(request.data.get("amount")) # 입력값
-    from_currency = request.data.get("from_currency") 
-    to_currency = request.data.get("to_currency")
-    
-    exchange_rates = get_exchange_rates(request).data
-
-    if from_currency == 'KRW':
-        result = amount / exchange_rates[to_currency]
-    elif to_currency == 'KRW':
-        result = amount * exchange_rates[from_currency]
-    else:
-        result = (amount * exchange_rates[from_currency]) / exchange_rates[to_currency]
-
-
-    return Response({'result': round(result, 2)})
-
-    


### PR DESCRIPTION
1. 백엔드에서 환율계산하는 로직 삭제하고 프론트에서 계산하는 걸로 변경
2. cur_unit(통화코드)과 deal_bas_r(매매기준율)만 전달하던 것에서 -> cur_nm(통화명)도 같이 전달하는 걸로 변경
3. UI에서 오른쪽에 cur_nm(통화명)도 같이 표시하도록 변경